### PR TITLE
Update enter-chroot

### DIFF
--- a/host-bin/enter-chroot
+++ b/host-bin/enter-chroot
@@ -650,7 +650,7 @@ if [ "$NOLOGIN" != 1 ] && grep -q '^root:' "$passwd" 2>/dev/null; then
     # If it fails, or if the user does not exist, `id -un '$dbususer'`
     # will fail, and we fallback on a default user name ("messagebus")
     dbususer="`echo "cat /busconfig/user/text()" \
-        | xmllint --shell "$CHROOT/etc/dbus-1/system.conf" 2>/dev/null \
+        | xmllint --shell "$CHROOT/usr/share/dbus-1/system.conf" 2>/dev/null \
         | grep '^[a-z][-a-z0-9_]*$' || true`"
     chrootcmd "
         if ! hash dbus-daemon 2>/dev/null; then
@@ -666,8 +666,8 @@ if [ "$NOLOGIN" != 1 ] && grep -q '^root:' "$passwd" 2>/dev/null; then
             rm -f "$pidfile"
         fi
         mkdir -p /var/run/dbus
-        dbususer="`id -un "$dbususer" 2>/dev/null || echo "dbus"`"
-        dbusgrp="`id -gn "$dbususer" 2>/dev/null || echo "dbus"`"
+        dbususer="`id -un "$dbususer" 2>/dev/null || echo "messagebus"`"
+        dbusgrp="`id -gn "$dbususer" 2>/dev/null || echo "messagebus"`"
         chown "$dbususer:$dbusgrp" /var/run/dbus
         exec dbus-daemon --system --fork' || ret=$?
     if [ "$ret" != 0 ]; then


### PR DESCRIPTION
This fixes [issue 123](https://github.com/drinkcat/chroagh/issues/123), where `enter-chroot` complains about `chown: invalid user: 'messagebus:messagebus'`, by pointing drinkcat's config parsing code to the right file. This is because `/etc/dbus-1/system.conf` has moved to `/usr/share/dbus-1/system.conf` in newer versions of D-Bus.