### PR TITLE
Temporarily deal with issue #1

### DIFF
--- a/installer/arch/bootstrap
+++ b/installer/arch/bootstrap
@@ -203,6 +203,10 @@ sh -e $BINDIR/enter-chroot -x -c "$(dirname $BOOTSTRAPCHROOT)" \
             pacman-key --populate archlinuxarm
         fi
 
+        # TODO: figure out less hacky way to add mirror
+        # https://github.com/mediocregopher/chroagh/issues/1
+        echo 'Server = $MIRROR' >> /etc/pacman.d/mirrorlist
+
         # Force overwritting packages files in the bootstrap, without any sort
         # of dependency checking: this makes sure package content are properly
         # recorded


### PR DESCRIPTION
This temporarily addresses issue #1. After merging this commit, chroagh should work out-of-the-box on x86 platforms too. There shouldn't be any problems with [enabling multiple mirrors](https://wiki.archlinux.org/index.php/mirrors#Enabling_a_specific_mirror), especially since the user has to specify a valid `$MIRROR` for downloading the initial image anyway.