### PR TITLE
Fix issue #6 by updating gtk-extra target

### DIFF
--- a/targets/gtk-extra
+++ b/targets/gtk-extra
@@ -9,11 +9,12 @@ DESCRIPTION='GTK-based tools including gdebi and a simple browser.'
 ### Append to prepare.sh:
 if [ "${DISTROAKA:-"$DISTRO"}" != 'arch' ]; then
     install_dummy network-manager network-manager-gnome
+    install gdebi
     if release -lt buster -lt kali-rolling -lt artful; then
       install gksu
     fi
 fi
-install arch=,gdebi gksu arch=netsurf,netsurf-gtk
+install arch=,gdebi arch=,netsurf
 
 if [ "${DISTROAKA:-"$DISTRO"}" = 'debian' ]; then
     for BROWSER in netsurf-gtk dillo hv3 ""; do


### PR DESCRIPTION
This fixes issue #6, where the xfce target is broken, by updating the gtk-extra target. Unfortunately, due to issue #5, the xfce target is still useless.

This pull request makes the following changes:
- remove gksu, which has been removed from [official Arch repositories](https://lists.archlinux.org/pipermail/arch-dev-public/2018-April/029224.html), as well as removed from [recent Debian distros](https://github.com/dnschneid/crouton/pull/3624).
- remove netsurf-gtk, which has also been removed from [recent Debian distros](https://github.com/dnschneid/crouton/pull/2516).
- add [line 12 to targets/gtk-extra](https://github.com/eyqs/chroagh/blob/a3b5385384c5a5f0ab7b1e746123abda8486bc1a/targets/gtk-extra#L12) to sync it with [the crouton targets/gtk-extra](https://github.com/dnschneid/crouton/blob/06503d3ec4b68863ec44b57d925f94797ec6b9ef/targets/gtk-extra).